### PR TITLE
Fix inconsistency in `Location.toText`.

### DIFF
--- a/library/ROC/ID/Location/Internal.hs
+++ b/library/ROC/ID/Location/Internal.hs
@@ -105,7 +105,7 @@ toTextEnglish (Location letter) = case letter of
   O -> "Hsinchu City"
   P -> "Yunlin County"
   Q -> "Chiayi County"
-  R -> "Pingtung County"
+  R -> "Tainan County"
   S -> "Kaohsiung County"
   T -> "Pingtung County"
   U -> "Hualien County"


### PR DESCRIPTION
This PR fixes the English translation for location code `R` to map to "Tainan County".