### PR TITLE
Don't derive `Bounded` for `CharIndex`.

### DIFF
--- a/library/ROC/ID/Number/Unchecked.hs
+++ b/library/ROC/ID/Number/Unchecked.hs
@@ -50,7 +50,7 @@ data IdentityNumber = IdentityNumber
 --
 newtype CharIndex = CharIndex Int
   deriving stock (Read, Show)
-  deriving newtype (Bounded, Enum, Eq, Num, Ord)
+  deriving newtype (Enum, Eq, Num, Ord)
 
 -- | Specifies a set of characters.
 --


### PR DESCRIPTION
This instance is redundant.