### PR TITLE
Simplify error handling for `ID.fromText`.

### DIFF
--- a/components/roc-id-test/Spec.hs
+++ b/components/roc-id-test/Spec.hs
@@ -178,12 +178,12 @@ main = hspec $ do
       property $ \(i :: ID) n -> do
         let newLength = n `mod` 10
         let invalidID = T.take newLength $ ID.toText i
-        ID.fromText invalidID `shouldBe` Left ID.TextTooShort
+        ID.fromText invalidID `shouldBe` Left ID.InvalidLength
 
     it "does not parse identification numbers that are too long" $
       property $ \(i :: ID) (NonEmpty s) -> do
         let invalidID = ID.toText i <> T.pack s
-        ID.fromText invalidID `shouldBe` Left ID.TextTooLong
+        ID.fromText invalidID `shouldBe` Left ID.InvalidLength
 
     it "does not parse identification numbers with invalid location codes" $
       property $ \(i :: ID) (c :: Int) -> do
@@ -227,7 +227,7 @@ main = hspec $ do
               replaceCharAt invalidCharIndex 'x' (ID.toText i)
               <>
               T.pack trailingExcess
-        ID.fromText textInvalid `shouldBe` Left ID.TextTooLong
+        ID.fromText textInvalid `shouldBe` Left ID.InvalidLength
 
 -- | Replaces a character at a specific position.
 --

--- a/components/roc-id/ROC/ID.hs
+++ b/components/roc-id/ROC/ID.hs
@@ -232,12 +232,10 @@ fromText text = do
   where
     fromUncheckedError :: U.FromTextError -> FromTextError
     fromUncheckedError = \case
-      U.TextTooShort ->
-        TextTooShort
-      U.TextTooLong ->
-        TextTooLong
       U.InvalidChar i r ->
         InvalidChar i r
+      U.InvalidLength ->
+        InvalidLength
 
 unsafeFromText :: Text -> ID
 unsafeFromText t =
@@ -249,13 +247,7 @@ unsafeFromText t =
 --
 data FromTextError
 
-  = TextTooShort
-  -- ^ Indicates that the input text is too short.
-
-  | TextTooLong
-  -- ^ Indicates that the input text is too long.
-
-  | InvalidChar CharIndex CharSet
+  = InvalidChar CharIndex CharSet
   -- ^ Indicates that the input text contains a character that is not allowed.
   --
   --   - `CharIndex` specifies the position of the invalid character.
@@ -263,6 +255,9 @@ data FromTextError
 
   | InvalidChecksum
   -- ^ Indicates that the parsed identification number has an invalid checksum.
+
+  | InvalidLength
+  -- ^ Indicates that the input text has an invalid length.
 
   deriving stock (Eq, Ord, Show)
 

--- a/components/roc-id/ROC/ID/Unchecked.hs
+++ b/components/roc-id/ROC/ID/Unchecked.hs
@@ -90,16 +90,15 @@ type UncheckedIDTuple =
   )
 
 data FromTextError
-  = TextTooShort
-  | TextTooLong
-  | InvalidChar CharIndex CharSet
+  = InvalidChar CharIndex CharSet
+  | InvalidLength
   deriving stock (Eq, Ord, Read, Show)
 
 type Parser a = Text -> Either FromTextError (Text, a)
 
 fromText :: Text -> Either FromTextError UncheckedID
 fromText text0 = do
-    when (T.length text0 > 10) $ Left TextTooLong
+    when (T.length text0 > 10) $ Left InvalidLength
     (text1,  c0                             ) <- parseLetter    text0
     (text2,  c1                             ) <- parseDigit1289 text1
     (_____, (c2, c3, c4, c5, c6, c7, c8, c9)) <- parseDigits    text2
@@ -107,13 +106,13 @@ fromText text0 = do
   where
     parseLetter :: Parser Letter
     parseLetter text = do
-      (char, remainder) <- guard TextTooShort $ T.uncons text
+      (char, remainder) <- guard InvalidLength $ T.uncons text
       letter <- guard (InvalidChar 0 (CharRange 'A' 'Z')) (Letter.fromChar char)
       pure (remainder, letter)
 
     parseDigit1289 :: Parser Digit1289
     parseDigit1289 text = do
-      (char, remainder) <- guard TextTooShort $ T.uncons text
+      (char, remainder) <- guard InvalidLength $ T.uncons text
       digit1289 <- guard
         (InvalidChar 1 (CharSet $ NESet.fromList $ '1' :| ['2', '8', '9']))
         (Digit1289.fromChar char)
@@ -123,7 +122,7 @@ fromText text0 = do
     parseDigits text = do
         let (chars, remainder) = T.splitAt 8 text
         digitList <- traverse parseIndexedDigit (zip [2 ..] $ T.unpack chars)
-        digitTuple <- guard TextTooShort (listToTuple8 digitList)
+        digitTuple <- guard InvalidLength (listToTuple8 digitList)
         pure (remainder, digitTuple)
       where
         parseIndexedDigit (i, c) =


### PR DESCRIPTION
This commit simplifies error handling for `ID.fromText` by merging the `TextTooShort` and `TextTooLong` errors into a unified `InvalidLength` error.